### PR TITLE
#121 以前までの会話のメモリを保持するようにする(フロント側で) 

### DIFF
--- a/backend/fast-api/models.py
+++ b/backend/fast-api/models.py
@@ -65,3 +65,21 @@ class SentimentResponse(BaseModel):
     """感情分析レスポンスモデル"""
     results: List[SentimentResult] = Field(..., description="分析結果のリスト")
     metadata: Dict[str, Any] = Field(..., description="処理に関するメタデータ")
+
+
+class ConversationMessage(BaseModel):
+    """会話履歴の単一メッセージ"""
+    role: Literal["user", "assistant"] = Field(..., description="メッセージの送信者")
+    content: str = Field(..., description="メッセージの内容")
+
+
+class QueryRequestWithHistory(BaseModel):
+    """会話履歴を含むクエリリクエスト"""
+    query: str = Field(..., description="ユーザーのクエリ")
+    conversation_history: Optional[List[ConversationMessage]] = Field(
+        default=[], 
+        description="過去の会話履歴"
+    )
+    context: Optional[Dict[str, Any]] = Field(None, description="追加のコンテキスト情報")
+    language: Optional[str] = Field("ja", description="言語設定")
+    stream: Optional[bool] = Field(True, description="ストリーミング応答を使用するか")

--- a/backend/fast-api/routers/llm.py
+++ b/backend/fast-api/routers/llm.py
@@ -12,6 +12,7 @@ import asyncio
 from datetime import datetime
 
 from config import settings, logger
+from models import ConversationMessage, QueryRequestWithHistory
 
 router = APIRouter(
     tags=["llm"],
@@ -19,7 +20,7 @@ router = APIRouter(
 )
 
 class QueryRequest(BaseModel):
-    """ユーザークエリのリクエストモデル"""
+    """ユーザークエリのリクエストモデル（後方互換性用）"""
     query: str # 質問の文字列
     context: Optional[Dict[str, Any]] = None # 追加のコンテキスト情報(オプション)
     language: Optional[str] = None # 応答言語
@@ -37,6 +38,40 @@ class StreamChunk(BaseModel):
     content: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
     timestamp: str
+
+
+def format_conversation_history(
+    history: list[ConversationMessage], 
+    max_length: int = 1200
+) -> str:
+    """
+    会話履歴を文字列にフォーマット
+    """
+    if not history:
+        return ""
+    
+    formatted_messages = []
+    total_length = 0
+    
+    # 新しい順に処理（最新の会話を優先）
+    for msg in reversed(history):
+        role_label = "ユーザー" if msg.role == "user" else "アシスタント"
+        formatted = f"{role_label}: {msg.content}"
+        
+        if total_length + len(formatted) > max_length:
+            break
+            
+        formatted_messages.insert(0, formatted)
+        total_length += len(formatted)
+    
+    return "\n".join(formatted_messages)
+
+
+def get_conversation_context(context: str) -> dict:
+    """
+    会話コンテキストを単一フィールドで返す（Difyの段落対応により分割不要）
+    """
+    return {"conversation_context": context}
 
 async def stream_dify_response(
     workflow_id: str,
@@ -207,15 +242,24 @@ async def call_dify_workflow_blocking(
         return result.get("data", {}).get("outputs", {}).get("response", "応答を生成できませんでした。")
 
 @router.post("/query")
-async def process_query(request: QueryRequest):
+async def process_query(request: QueryRequestWithHistory):
     """
-    ユーザークエリを処理する（ストリーミング/非ストリーミング両対応）
+    ユーザークエリを処理する（会話履歴対応版）
     """
     try:
+        # 会話履歴をフォーマット
+        history_context = format_conversation_history(
+            request.conversation_history or []
+        )
+        
+        # 会話コンテキストを単一フィールドで設定
+        context_data = get_conversation_context(history_context)
+        
         inputs = {
             "user_input": request.query,
             "language": request.language or "ja",
-            "stream": request.stream and settings.enable_streaming
+            "stream": request.stream and settings.enable_streaming,
+            **context_data
         }
         
         if request.stream and settings.enable_streaming:
@@ -246,14 +290,23 @@ async def process_query(request: QueryRequest):
         raise HTTPException(status_code=500, detail="Error processing response")
 
 @router.post("/voice_mode_answer")
-async def process_voice_mode_answer(request: QueryRequest):
+async def process_voice_mode_answer(request: QueryRequestWithHistory):
     """
-    音声モード用の処理
+    音声モード用の処理（会話履歴対応版）
     """
     try:
+        # 会話履歴をフォーマット
+        history_context = format_conversation_history(
+            request.conversation_history or []
+        )
+        
+        # 会話コンテキストを単一フィールドで設定
+        context_data = get_conversation_context(history_context)
+        
         inputs = {
             "user_input": request.query,
-            "language": request.language or "ja"
+            "language": request.language or "ja",
+            **context_data
         }
         
         # ストリーミングが有効な場合はストリーミングレスポンスを返す
@@ -290,15 +343,24 @@ async def process_voice_mode_answer(request: QueryRequest):
         raise HTTPException(status_code=500, detail="Error processing response")
 
 @router.post("/query_non_streaming")
-async def process_query_non_streaming(request: QueryRequest):
+async def process_query_non_streaming(request: QueryRequestWithHistory):
     """
-    ユーザークエリを処理する（非ストリーミング専用）
+    ユーザークエリを処理する（非ストリーミング専用、会話履歴対応版）
     """
     try:
+        # 会話履歴をフォーマット
+        history_context = format_conversation_history(
+            request.conversation_history or []
+        )
+        
+        # 会話コンテキストを単一フィールドで設定
+        context_data = get_conversation_context(history_context)
+        
         inputs = {
             "user_input": request.query,
             "language": request.language or "ja",
-            "stream": False
+            "stream": False,
+            **context_data
         }
         
         # 強制的に非ストリーミングで処理

--- a/backend/fast-api/tests/test_llm_with_history.py
+++ b/backend/fast-api/tests/test_llm_with_history.py
@@ -1,0 +1,335 @@
+"""
+会話履歴機能を含むLLMエンドポイントのテスト
+"""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, patch
+import json
+import asyncio
+
+from main import app
+from models import ConversationMessage, QueryRequestWithHistory
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def sample_conversation_history():
+    """テスト用の会話履歴"""
+    return [
+        ConversationMessage(role="user", content="金沢工業大学について教えて"),
+        ConversationMessage(role="assistant", content="金沢工業大学は1965年に設立された私立大学です。"),
+        ConversationMessage(role="user", content="学部はどのようなものがありますか？")
+    ]
+
+
+@pytest.fixture
+def sample_request_with_history(sample_conversation_history):
+    """会話履歴を含むリクエストボディ"""
+    return {
+        "query": "それについてもっと詳しく教えて",
+        "conversation_history": [msg.model_dump() for msg in sample_conversation_history],
+        "language": "ja",
+        "stream": False
+    }
+
+
+class TestLLMWithHistory:
+    """会話履歴機能のテストクラス"""
+    
+    def test_conversation_message_validation(self):
+        """ConversationMessageモデルのバリデーションテスト"""
+        # 正常なケース
+        msg = ConversationMessage(role="user", content="テストメッセージ")
+        assert msg.role == "user"
+        assert msg.content == "テストメッセージ"
+        
+        # 無効なroleのテスト
+        with pytest.raises(ValueError):
+            ConversationMessage(role="invalid_role", content="テスト")
+    
+    def test_query_request_with_history_validation(self):
+        """QueryRequestWithHistoryモデルのバリデーションテスト"""
+        # 正常なケース（履歴なし）
+        request = QueryRequestWithHistory(query="テストクエリ")
+        assert request.query == "テストクエリ"
+        assert request.conversation_history == []
+        assert request.language == "ja"
+        assert request.stream is True
+        
+        # 履歴ありのケース
+        history = [
+            ConversationMessage(role="user", content="こんにちは"),
+            ConversationMessage(role="assistant", content="こんにちは！")
+        ]
+        request = QueryRequestWithHistory(
+            query="元気ですか？",
+            conversation_history=history,
+            language="en",
+            stream=False
+        )
+        assert len(request.conversation_history) == 2
+        assert request.language == "en"
+        assert request.stream is False
+
+    @patch('routers.llm.call_dify_workflow_blocking')
+    def test_query_endpoint_with_history_non_streaming(self, mock_dify, sample_request_with_history):
+        """非ストリーミングモードでの会話履歴テスト"""
+        # Difyのレスポンスをモック
+        mock_dify.return_value = "金沢工業大学には工学部、情報フロンティア学部、建築学部、バイオ・化学部があります。"
+        
+        response = client.post("/api/llm/query", json=sample_request_with_history)
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "answer" in data
+        assert "金沢工業大学" in data["answer"]
+        
+        # Difyが正しい引数で呼ばれたかチェック
+        mock_dify.assert_called_once()
+        call_args = mock_dify.call_args
+        inputs = call_args[1]["inputs"]  # キーワード引数から取得
+        
+        assert "user_input" in inputs
+        assert inputs["user_input"] == "それについてもっと詳しく教えて"
+        
+        # 分割された会話コンテキストが含まれていることを確認
+        assert "conversation_context_1" in inputs
+        assert "conversation_context_2" in inputs
+        assert "conversation_context_3" in inputs
+        assert "conversation_context_4" in inputs
+        assert "conversation_context_5" in inputs
+        
+        # 少なくとも最初のチャンクに会話履歴が含まれていることを確認
+        combined_context = inputs["conversation_context_1"] + inputs["conversation_context_2"]
+        assert "ユーザー:" in combined_context
+        assert "アシスタント:" in combined_context
+
+    @patch('routers.llm.stream_dify_response')
+    def test_query_endpoint_with_history_streaming(self, mock_stream, sample_conversation_history):
+        """ストリーミングモードでの会話履歴テスト"""
+        # ストリーミングレスポンスをモック
+        async def mock_stream_generator(*args, **kwargs):
+            yield json.dumps({
+                "id": "test_id",
+                "type": "content",
+                "content": "工学部には機械工学科、",
+                "timestamp": "2024-01-01T00:00:00Z"
+            }) + "\n"
+            yield json.dumps({
+                "id": "test_id", 
+                "type": "content",
+                "content": "電気電子工学科があります。",
+                "timestamp": "2024-01-01T00:00:01Z"
+            }) + "\n"
+            yield json.dumps({
+                "id": "test_id",
+                "type": "done",
+                "content": "",
+                "timestamp": "2024-01-01T00:00:02Z"
+            }) + "\n"
+        
+        mock_stream.return_value = mock_stream_generator()
+        
+        request_data = {
+            "query": "工学部について詳しく教えて",
+            "conversation_history": [msg.model_dump() for msg in sample_conversation_history],
+            "stream": True,
+            "language": "ja"
+        }
+        
+        response = client.post("/api/llm/query", json=request_data)
+        
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+        
+        # ストリーミング関数が正しい引数で呼ばれたかチェック
+        mock_stream.assert_called_once()
+
+    def test_query_endpoint_empty_history(self):
+        """空の会話履歴でのテスト"""
+        request_data = {
+            "query": "金沢工業大学について教えて",
+            "conversation_history": [],
+            "stream": False,
+            "language": "ja"
+        }
+        
+        with patch('routers.llm.call_dify_workflow_blocking') as mock_dify:
+            mock_dify.return_value = "金沢工業大学は1965年に設立された大学です。"
+            
+            response = client.post("/api/llm/query", json=request_data)
+            
+            assert response.status_code == 200
+            
+            # 空の履歴でも正常に動作することを確認
+            call_args = mock_dify.call_args
+            inputs = call_args[1]["inputs"]
+            # 全ての分割フィールドが空であることを確認
+            for i in range(1, 6):
+                assert inputs[f"conversation_context_{i}"] == ""
+
+    def test_query_endpoint_without_history_field(self):
+        """conversation_historyフィールドがない場合のテスト（後方互換性）"""
+        request_data = {
+            "query": "テストクエリ",
+            "stream": False,
+            "language": "ja"
+        }
+        
+        with patch('routers.llm.call_dify_workflow_blocking') as mock_dify:
+            mock_dify.return_value = "テスト応答"
+            
+            response = client.post("/api/llm/query", json=request_data)
+            
+            assert response.status_code == 200
+            
+            # 履歴フィールドがなくても正常に動作することを確認
+            call_args = mock_dify.call_args
+            inputs = call_args[1]["inputs"]
+            # 全ての分割フィールドが空であることを確認
+            for i in range(1, 6):
+                assert inputs[f"conversation_context_{i}"] == ""
+
+    @patch('routers.llm.call_dify_workflow_blocking')
+    def test_voice_mode_endpoint_with_history(self, mock_dify, sample_conversation_history):
+        """音声モードエンドポイントでの会話履歴テスト"""
+        request_data = {
+            "query": "続きを教えて",
+            "conversation_history": [msg.model_dump() for msg in sample_conversation_history],
+            "stream": False,
+            "language": "ja"
+        }
+        
+        mock_dify.return_value = "音声モードでの応答です。"
+        
+        response = client.post("/api/llm/voice_mode_answer", json=request_data)
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert "answer" in data
+        
+        # 会話履歴が正しく処理されていることを確認
+        call_args = mock_dify.call_args
+        inputs = call_args[1]["inputs"]
+        
+        # 分割された会話コンテキストが含まれていることを確認
+        combined_context = ""
+        for i in range(1, 6):
+            combined_context += inputs[f"conversation_context_{i}"]
+        assert "ユーザー:" in combined_context
+
+    def test_format_conversation_history_function(self):
+        """format_conversation_history関数の単体テスト"""
+        from routers.llm import format_conversation_history
+        
+        # 空の履歴
+        assert format_conversation_history([]) == ""
+        
+        # 通常の履歴
+        history = [
+            ConversationMessage(role="user", content="こんにちは"),
+            ConversationMessage(role="assistant", content="こんにちは！元気ですか？"),
+            ConversationMessage(role="user", content="元気です")
+        ]
+        
+        result = format_conversation_history(history)
+        lines = result.split("\n")
+        
+        assert len(lines) == 3
+        assert lines[0] == "ユーザー: こんにちは"
+        assert lines[1] == "アシスタント: こんにちは！元気ですか？"
+        assert lines[2] == "ユーザー: 元気です"
+
+    def test_format_conversation_history_with_length_limit(self):
+        """文字数制限ありでのformat_conversation_history関数テスト"""
+        from routers.llm import format_conversation_history
+        
+        history = [
+            ConversationMessage(role="user", content="短いメッセージ"),
+            ConversationMessage(role="assistant", content="これは非常に長いメッセージです。" * 10),
+            ConversationMessage(role="user", content="最新のメッセージ")
+        ]
+        
+        # 短い制限で最新メッセージが優先されることを確認
+        result = format_conversation_history(history, max_length=50)
+        assert "最新のメッセージ" in result
+        assert len(result) <= 50
+
+    def test_split_conversation_context_function(self):
+        """split_conversation_context関数の単体テスト"""
+        from routers.llm import split_conversation_context
+        
+        # 短いコンテキスト
+        short_context = "ユーザー: こんにちは\nアシスタント: こんにちは！"
+        result = split_conversation_context(short_context)
+        
+        assert "conversation_context_1" in result
+        assert result["conversation_context_1"] == short_context
+        assert result["conversation_context_2"] == ""
+        assert result["conversation_context_3"] == ""
+        assert result["conversation_context_4"] == ""
+        assert result["conversation_context_5"] == ""
+
+    def test_split_conversation_context_long_text(self):
+        """長いテキストの分割テスト"""
+        from routers.llm import split_conversation_context
+        
+        # 250文字を超える長いコンテキスト
+        long_context = "ユーザー: " + "あ" * 300 + "\nアシスタント: " + "い" * 300
+        result = split_conversation_context(long_context, max_chunk_size=250)
+        
+        # 複数のチャンクに分割されていることを確認
+        assert len(result["conversation_context_1"]) == 250
+        assert len(result["conversation_context_2"]) == 250
+        assert len(result["conversation_context_3"]) > 0
+        
+        # 全チャンクを結合すると元のテキストになることを確認
+        combined = ""
+        for i in range(1, 6):
+            combined += result[f"conversation_context_{i}"]
+        assert combined.startswith(long_context)
+
+    def test_split_conversation_context_edge_cases(self):
+        """split_conversation_context関数のエッジケーステスト"""
+        from routers.llm import split_conversation_context
+        
+        # 空のコンテキスト
+        empty_result = split_conversation_context("")
+        for i in range(1, 6):
+            assert empty_result[f"conversation_context_{i}"] == ""
+        
+        # ちょうど250文字のコンテキスト
+        exact_context = "a" * 250
+        exact_result = split_conversation_context(exact_context)
+        assert exact_result["conversation_context_1"] == exact_context
+        assert exact_result["conversation_context_2"] == ""
+
+    def test_query_non_streaming_endpoint_with_history(self, sample_conversation_history):
+        """非ストリーミング専用エンドポイントでの会話履歴テスト"""
+        request_data = {
+            "query": "詳細を教えて",
+            "conversation_history": [msg.model_dump() for msg in sample_conversation_history],
+            "language": "ja"
+        }
+        
+        with patch('routers.llm.call_dify_workflow_blocking') as mock_dify:
+            mock_dify.return_value = "詳細な情報をお答えします。"
+            
+            response = client.post("/api/llm/query_non_streaming", json=request_data)
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert "answer" in data
+            
+            # 会話履歴が含まれていることを確認
+            call_args = mock_dify.call_args
+            inputs = call_args[1]["inputs"]
+            
+            # 分割されたコンテキストのいずれかに内容があることを確認
+            has_content = False
+            for i in range(1, 6):
+                if inputs[f"conversation_context_{i}"] != "":
+                    has_content = True
+                    break
+            assert has_content

--- a/frontend/src/features/ChatInterface/ChatInterface.tsx
+++ b/frontend/src/features/ChatInterface/ChatInterface.tsx
@@ -33,6 +33,7 @@ import { useStreamingTTS } from "../../hooks/useStreamingTTS";
 import { useTextToSpeech } from "../../hooks/useTextToSpeech";
 
 import {
+	type ConversationMessage,
 	buildPrompt,
 	generateTextNonStreaming,
 	generateTextStream,
@@ -223,6 +224,15 @@ export const ChatInterface = forwardRef<
 
 		streamingTTS.clearQueue();
 
+		// 会話履歴を準備（最新20件まで）
+		const conversationHistory: ConversationMessage[] = messages
+			.slice(-20)
+			.map((msg) => ({
+				role: (msg.isUser ? "user" : "assistant") as "user" | "assistant",
+				content: msg.text,
+			}))
+			.filter((msg) => msg.content.trim()); // 空のメッセージを除外
+
 		try {
 			const payloadQuery = buildPrompt(trimmed);
 
@@ -232,7 +242,7 @@ export const ChatInterface = forwardRef<
 
 				await generateTextStream(
 					payloadQuery,
-					undefined,
+					conversationHistory,
 					controller.signal,
 					(chunk) => {
 						if (chunk.type === "content" && chunk.content) {
@@ -292,7 +302,7 @@ export const ChatInterface = forwardRef<
 				// 非ストリーミングモード
 				const response = await generateTextNonStreaming(
 					payloadQuery,
-					undefined,
+					conversationHistory,
 					controller.signal,
 					currentLanguage,
 				);

--- a/frontend/src/features/SimpleMobileChat/SimpleMobileChat.tsx
+++ b/frontend/src/features/SimpleMobileChat/SimpleMobileChat.tsx
@@ -1,4 +1,8 @@
-import { buildPrompt, generateText } from "@/services/llmService";
+import {
+	type ConversationMessage,
+	buildPrompt,
+	generateText,
+} from "@/services/llmService";
 import { currentLanguageAtom } from "@/store/languageAtoms";
 import {
 	addSimpleChatMessageAtom,
@@ -54,11 +58,20 @@ export const SimpleMobileChat: React.FC = () => {
 			// AbortControllerで中断可能にする
 			abortRef.current = new AbortController();
 
+			// 会話履歴の準備（モバイルは履歴を少なめに10件）
+			const conversationHistory: ConversationMessage[] = messages
+				.slice(-10)
+				.map((msg) => ({
+					role: (msg.isUser ? "user" : "assistant") as "user" | "assistant",
+					content: msg.text,
+				}))
+				.filter((msg) => msg.content.trim()); // 空のメッセージを除外
+
 			try {
 				const payloadQuery = buildPrompt(userMessage);
 				const response = await generateText(
 					payloadQuery,
-					undefined, // conversationId
+					conversationHistory, // 履歴を追加
 					abortRef.current.signal, // signal
 					"/api/llm/query", // endpoint
 					currentLanguage, // language
@@ -85,7 +98,7 @@ export const SimpleMobileChat: React.FC = () => {
 				abortRef.current = null;
 			}
 		},
-		[addMessage, setIsThinking, currentLanguage, t],
+		[addMessage, setIsThinking, currentLanguage, messages, t],
 	);
 
 	// メッセージ送信処理

--- a/frontend/src/features/VoiceChat/VoiceChat.tsx
+++ b/frontend/src/features/VoiceChat/VoiceChat.tsx
@@ -1,5 +1,6 @@
 import { useTextToSpeech } from "@/hooks/useTextToSpeech";
 import {
+	type ConversationMessage,
 	type StreamChunk,
 	buildPrompt,
 	generateTextStream,
@@ -144,6 +145,17 @@ export const VoiceChat = ({ onClose, vrmWrapperRef }: VoiceChatProps) => {
 	const generateAIResponse = useCallback(
 		async (userInput: string) => {
 			try {
+				// 会話履歴の準備（音声チャットでは10件）
+				const conversationHistory: ConversationMessage[] = chatHistory
+					.slice(-10)
+					.map((msg) => ({
+						role: (msg.role === "user" ? "user" : "assistant") as
+							| "user"
+							| "assistant",
+						content: msg.content,
+					}))
+					.filter((msg) => msg.content.trim()); // 空のメッセージを除外
+
 				// プロンプトの構築
 				const payloadQuery = buildPrompt(userInput);
 				console.log(payloadQuery);
@@ -169,7 +181,7 @@ export const VoiceChat = ({ onClose, vrmWrapperRef }: VoiceChatProps) => {
 
 				await generateTextStream(
 					payloadQuery,
-					undefined, // conversationId
+					conversationHistory, // 履歴を追加
 					undefined, // signal
 					onChunk,
 					"/api/llm/query", // エンドポイント
@@ -196,6 +208,7 @@ export const VoiceChat = ({ onClose, vrmWrapperRef }: VoiceChatProps) => {
 		},
 		[
 			addAiMessage,
+			chatHistory,
 			setProcessingState,
 			setVrmThinkingState,
 			speakProgressive,

--- a/frontend/src/services/llmService.ts
+++ b/frontend/src/services/llmService.ts
@@ -1,5 +1,11 @@
 import type { SupportedLanguage } from "../store/languageAtoms";
 
+// 会話メッセージの型定義
+export type ConversationMessage = {
+	role: "user" | "assistant";
+	content: string;
+};
+
 // ストリーミングレスポンスの型定義
 export type StreamChunk = {
 	id: string;
@@ -30,15 +36,15 @@ export const buildPrompt = (query: string): string => {
  */
 export async function generateTextStream(
 	query: string,
-	conversationId: string | undefined,
-	signal: AbortSignal | undefined,
-	onChunk: (chunk: StreamChunk) => void,
+	conversationHistory?: ConversationMessage[],
+	signal?: AbortSignal,
+	onChunk?: (chunk: StreamChunk) => void,
 	endpoint = "/api/llm/query",
 	language: SupportedLanguage = "ja",
 ): Promise<void> {
 	const requestBody = {
 		query,
-		conversation_id: conversationId,
+		conversation_history: conversationHistory || [],
 		stream: true,
 		language,
 	};
@@ -74,7 +80,7 @@ export async function generateTextStream(
 				if (buffer.trim()) {
 					try {
 						const chunk = JSON.parse(buffer) as StreamChunk;
-						onChunk(chunk);
+						onChunk?.(chunk);
 					} catch (e) {
 						console.error("Error parsing final JSON chunk:", e);
 					}
@@ -92,7 +98,7 @@ export async function generateTextStream(
 				if (jsonString) {
 					try {
 						const chunk = JSON.parse(jsonString) as StreamChunk;
-						onChunk(chunk);
+						onChunk?.(chunk);
 					} catch (e) {
 						console.error(
 							"Error parsing JSON chunk:",
@@ -124,13 +130,13 @@ export async function generateTextStream(
  */
 export async function generateTextNonStreaming(
 	query: string,
-	conversationId?: string,
+	conversationHistory?: ConversationMessage[],
 	signal?: AbortSignal,
 	language: SupportedLanguage = "ja",
 ): Promise<string> {
 	const requestBody = {
 		query,
-		conversation_id: conversationId,
+		conversation_history: conversationHistory || [],
 		stream: false,
 		language,
 	};
@@ -175,7 +181,7 @@ export async function generateTextNonStreaming(
  */
 export async function generateText(
 	query: string,
-	conversationId?: string,
+	conversationHistory?: ConversationMessage[],
 	signal?: AbortSignal,
 	endpoint = "/api/llm/query",
 	language: SupportedLanguage = "ja",
@@ -194,7 +200,7 @@ export async function generateText(
 
 		generateTextStream(
 			query,
-			conversationId,
+			conversationHistory,
 			signal,
 			onChunk,
 			endpoint,


### PR DESCRIPTION
# #121 以前までの会話のメモリを保持するようにする(フロント側で) 
<!-- 変更の概要を簡潔に記載 -->

## 概要
<!-- このプルリクエストの目的や背景について簡潔に説明 -->
difyにユーザーからの質問だけでなくこれまでの会話履歴を渡すことでメモリ機能を実現した。  
非ログインでの運用を前提にするために、フロント側でキャッシュを持たせることで、ページリロード時にこれまでの文脈を忘れることができる。

## 変更内容
<!-- 実装内容や変更点の詳細を記載 -->
- これまでの会話履歴をLLMに渡す処理の追加

## 関連チケット/Issue
<!-- 関連するチケットやIssue番号があれば記載 -->
- Close #121 
- Ref # (参照Issue番号)

## 変更理由
<!-- 変更を行った理由や、解決したかった課題について記載 -->

## テスト手順
<!-- 動作確認やテスト手順を記載。手順通りに実施すれば、レビューアーやテスターが確認できるように詳細に書きます。 -->
1. [テスト手順1]
2. [テスト手順2]
3. [期待される結果]

## 影響範囲
<!-- この変更が影響する範囲やシステムへの影響を記載 -->
- [影響範囲1]
- [影響範囲2]

## チェックリスト
<!-- PRを出す前に確認すべき事項をリスト化 -->
- [ ] コードがビルドエラーなく実行できること
- [ ] 必要なテストが作成され、成功していること
- [ ] Linterを通過していること（例：ESLint）
- [ ] ドキュメント（READMEなど）が更新されていること
- [ ] レビュー担当者に影響点が共有されていること

## 補足情報
<!-- その他、レビューアーに伝えておきたい情報があれば記載 -->

<!-- Github Copilot コードレビューへの指示: 
このプルリクエストをレビューしてコメントする際は日本語でお願いします。 -->

## レビューに関して
レビューする際には、以下のprefix(接頭辞)を付けましょう。
<!-- for GitHub Copilot review rule -->
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
<!-- for GitHub Copilot review  rule-->


